### PR TITLE
Allow custom labels for clusters and node pools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,21 @@
-.terraform
+# Terraform working directory
+.terraform/
+
+# Terraform lock file
 .terraform.lock.hcl
+
+# Local TFVars files (often contain secrets, never commit!)
+*.tfvars
+*.tfvars.json
+
+# Terraform plan files
+*.tfplan
+
+# Crash log files
+crash.log
+
+# Ignore override files (local changes)
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ resource "scaleway_k8s_cluster" "k8s-cluster" {
   version                     = var.k8s_version
   cni                         = var.k8s_cni
   tags                        = var.tags
+  labels                      = var.cluster_labels
   delete_additional_resources = var.delete_additional_resources
   private_network_id          = var.private_network ? scaleway_vpc_private_network.private-network[0].id : null
 
@@ -55,6 +56,7 @@ resource "scaleway_k8s_pool" "k8s-cluster-pool" {
   max_size               = each.value.k8s_pool_max_size
   root_volume_type       = each.value.root_volume_type
   root_volume_size_in_gb = each.value.root_volume_size_in_gb
+  labels                 = var.pool_labels
   upgrade_policy {
     max_surge = each.value.upgrade_policy[0].max_surge
     max_unavailable =  each.value.upgrade_policy[0].max_unavailable

--- a/variables.tf
+++ b/variables.tf
@@ -123,3 +123,19 @@ variable "k8s_pools" {
     }))
   }))
 }
+
+# ==============================================
+# Labels for Cluster and Node Pools
+# ==============================================
+
+variable "cluster_labels" {
+  type        = map(string)
+  default     = {}
+  description = "Custom labels for the Kubernetes cluster"
+}
+
+variable "pool_labels" {
+  type        = map(string)
+  default     = {}
+  description = "Custom labels for each Kubernetes node pool"
+}


### PR DESCRIPTION
📝Description:
- This PR introduces the ability to specify `custom labels` for both the Scaleway Kubernetes cluster and each node pool via new input variables.
- Additionally, `.gitignore` is improved to follow Terraform best practices by ignoring sensitive and auto-generated files.

🛠️ Code Changes:
- `variables.tf`
   - Added `cluster_labels` (map) variable for Kubernetes cluster labels.
   - Added `pool_labels` (map) variable for Kubernetes node pool labels.

- `main.tf`
   - Injected `labels = var.cluster_labels` into `scaleway_k8s_cluster.k8s-cluster` resource.
   - Injected `labels = var.pool_labels` into `scaleway_k8s_pool.k8s-cluster-pool` resource.

- `.gitignore` - improved to ignore:
```
.terraform/
.terraform.lock.hcl
*.tfvars
*.tfvars.json
*.tfplan
crash.log
override.tf, override.tf.json, *_override.tf, *_override.tf.json
```

🎯Motivation:
- Allow users to customize and manage resource metadata (labels) easily.
- Make `.gitignore` Terraform-appropriate to avoid leaking sensitive information and unnecessary files into Git.